### PR TITLE
Update Android Setup Documentation

### DIFF
--- a/docs/android-setup.md
+++ b/docs/android-setup.md
@@ -25,7 +25,7 @@ dependencies {
 }
 ```
 
-Inside `gradle.properties` insert thoose global properties:
+Inside `gradle.properties` insert those global properties:
 ```groovy
-artifactory_contentUrl = "https://artifacts.sency.ai/artifactory/release"
+artifactory_contentUrl = https://artifacts.sency.ai/artifactory/release
 ```


### PR DESCRIPTION
Adding the suggested code, otherwise the file path resolves to:

```
node_modules/@sency/react-native-smkit-ui/android/"https:/artifacts.sency.ai/artifactory/release"/com/sency/smkitui/smkitui/0.1.6/smkitui-0.1.6.pom
```

Which then results in

```
Could not determine the dependencies of task ':sency_react-native-smkit-ui:compileDebugJavaWithJavac'.
> Could not resolve all task dependencies for configuration ':sency_react-native-smkit-ui:debugCompileClasspath'.
   > Could not find com.sency.smkitui:smkitui:0.1.6.
```